### PR TITLE
Retain resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  rev: v1.2.3
+  hooks:
+  - id: autopep8-wrapper
+  - id: check-added-large-files
+  - id: check-json
+  - id: check-yaml
+  - id: debug-statements
+  - id: detect-aws-credentials
+  - id: detect-private-key
+  - id: end-of-file-fixer
+  - id: flake8
+  - id: name-tests-test
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
   rev: v1.2.3
   hooks:
-  - id: autopep8-wrapper
   - id: check-added-large-files
   - id: check-json
   - id: check-yaml

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -372,6 +372,9 @@ A stack has the following keys:
   that will be applied when the CloudFormation stack is created and updated.
   You can use stack policies to prevent CloudFormation from making updates to
   protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
+**retain_resources**:
+  (optional): If provided, specifies a list of resources to retain when deleting
+  a stack. See https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteStack.html
 
 Stacks Example
 ~~~~~~~~~~~~~~

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -6,6 +6,7 @@ from ..exceptions import StackDoesNotExist
 from .. import util
 from ..status import (
     CompleteStatus,
+    FailedStatus,
     SubmittedStatus,
     SUBMITTED,
     INTERRUPTED
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 DestroyedStatus = CompleteStatus("stack destroyed")
 DestroyingStatus = SubmittedStatus("submitted for destruction")
+DestroyFailed = FailedStatus("stack destroy failed")
 
 
 class Action(BaseAction):
@@ -66,13 +68,38 @@ class Action(BaseAction):
             provider.get_stack_name(provider_stack),
             provider.get_stack_status(provider_stack),
         )
+
+        logger.debug("Destroying stack: %s", stack.fqn)
+
+        # Below there are three checks to see if the stack has failed.
+        # Unfortunately this is to handle a rather obscure corner case.
+        # In order to delete a Lambda@Edge resource StackDestroy must
+        # be called twice. Once without RetainResources, then again with
+        # RetainResources since the stack _must_ be in a failed state for
+        # RetainResources to work. The checks are there to make this
+        # function idempotent across stacker destroy runs.
+        #
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteStack.html
+
+        if not provider.is_stack_failed(provider_stack):
+            provider.destroy_stack(provider_stack)
+
+        if provider.is_stack_failed(provider_stack):
+            retain_resources = stack.retain_resources(self.provider)
+            if len(retain_resources):
+                provider_stack[u'RetainResources'] = retain_resources
+                provider.destroy_stack(provider_stack)
+                return DestroyedStatus
+
         if provider.is_stack_destroyed(provider_stack):
             return DestroyedStatus
-        elif provider.is_stack_in_progress(provider_stack):
+
+        if provider.is_stack_in_progress(provider_stack):
             return DestroyingStatus
-        else:
-            logger.debug("Destroying stack: %s", stack.fqn)
-            provider.destroy_stack(provider_stack)
+
+        if provider.is_stack_failed(provider_stack):
+            return DestroyFailed
+
         return DestroyingStatus
 
     def pre_run(self, outline=False, *args, **kwargs):

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -299,6 +299,8 @@ class Stack(Model):
 
     stack_policy_path = StringType(serialize_when_none=False)
 
+    retain_resources = ListType(StringType, serialize_when_none=False)
+
     def validate_class_path(self, data, value):
         if value and data["template_path"]:
             raise ValidationError(

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -23,6 +23,13 @@ class UnknownLookupType(Exception):
         super(UnknownLookupType, self).__init__(message, *args, **kwargs)
 
 
+class InterpolationFailed(Exception):
+
+    def __init__(self, variable_name, *args, **kwargs):
+        message = "Interpolation for variable `%s` failed." % variable_name
+        super(InterpolationFailed, self).__init__(message, *args, **kwargs)
+
+
 class FailedVariableLookup(Exception):
 
     def __init__(self, variable_name, error, *args, **kwargs):

--- a/stacker/lookups/handlers/hook_data.py
+++ b/stacker/lookups/handlers/hook_data.py
@@ -14,4 +14,13 @@ def handler(value, context, **kwargs):
         raise ValueError("Invalid value for hook_data: %s. Must be in "
                          "<hook_name>::<key> format." % value)
 
-    return context.hook_data[hook_name][key]
+    try:
+        data = context.hook_data[hook_name]
+    except KeyError:
+        s = "%s not in %s" % (hook_name, context.hook_data.keys())
+        raise KeyError(s)
+
+    try:
+        return data[key]
+    except KeyError:
+        raise KeyError("%s not in %s" % (key, data.keys()))

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from stacker.exceptions import FailedVariableLookup
 
 TYPE_NAME = "output"
 
@@ -23,7 +24,10 @@ def handler(value, context=None, **kwargs):
 
     d = deconstruct(value)
     stack = context.get_stack(d.stack_name)
-    return stack.outputs[d.output_name]
+    try:
+        return stack.outputs[d.output_name]
+    except KeyError:
+        raise KeyError("%s not in %s" % (d.output_name, stack.outputs.keys()))
 
 
 def deconstruct(value):

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -23,7 +23,11 @@ def handler(value, context=None, **kwargs):
         raise ValueError('Context is required')
 
     d = deconstruct(value)
+
     stack = context.get_stack(d.stack_name)
+    if stack.outputs is None:
+        raise ValueError("No outputs for %s" % (d.stack_name))
+
     try:
         return stack.outputs[d.output_name]
     except KeyError:

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -1,4 +1,7 @@
-from ..exceptions import UnknownLookupType
+from ..exceptions import (
+    InterpolationFailed,
+    UnknownLookupType,
+)
 from ..util import load_object_from_string
 
 from .handlers import output
@@ -60,6 +63,8 @@ def resolve_lookups(lookups, context, provider):
     """
     resolved_lookups = {}
     for lookup in lookups:
+        if lookup.type is None:
+            raise InterpolationFailed(lookup.input)
         try:
             handler = LOOKUP_HANDLERS[lookup.type]
         except KeyError:

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -614,7 +614,6 @@ class Provider(BaseProvider):
                 return
 
     def destroy_stack(self, stack, **kwargs):
-        from pprint import pprint
         logger.debug("Destroying stack: %s" % (self.get_stack_name(stack)))
         args = {"StackName": self.get_stack_name(stack)}
         if self.service_role:

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -614,10 +614,16 @@ class Provider(BaseProvider):
                 return
 
     def destroy_stack(self, stack, **kwargs):
+        from pprint import pprint
         logger.debug("Destroying stack: %s" % (self.get_stack_name(stack)))
         args = {"StackName": self.get_stack_name(stack)}
         if self.service_role:
             args["RoleARN"] = self.service_role
+
+        try:
+            args["RetainResources"] = stack["RetainResources"]
+        except KeyError:
+            pass
 
         self.cloudformation.delete_stack(**args)
         return True

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -3,8 +3,6 @@ import copy
 from . import util
 from .variables import (
     Variable,
-    extract_lookups,
-    resolve_lookups,
     resolve_variables,
 )
 from .lookups.handlers.output import (
@@ -118,6 +116,10 @@ class Stack(object):
         if not hasattr(self, "_retain_resources"):
             # XXX: do we want to do variable expansion here?
             """
+            from .variables import (
+                extract_lookups,
+                resolve_lookups,
+            )
             self._retain_resources = resolve_lookups(
                 extract_lookups(
                     self.definition.retain_resources,
@@ -126,7 +128,7 @@ class Stack(object):
                 provider,
             ).values()
             """
-            self._retain_resources = self.definition.retain_resources
+            self._retain_resources = self.definition.retain_resources or []
 
         return self._retain_resources
 

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -3,6 +3,8 @@ import copy
 from . import util
 from .variables import (
     Variable,
+    extract_lookups,
+    resolve_lookups,
     resolve_variables,
 )
 from .lookups.handlers.output import (
@@ -111,6 +113,22 @@ class Stack(object):
                     self._stack_policy = f.read()
 
         return self._stack_policy
+
+    def retain_resources(self, provider):
+        if not hasattr(self, "_retain_resources"):
+            # XXX: do we want to do variable expansion here?
+            """
+            self._retain_resources = resolve_lookups(
+                extract_lookups(
+                    self.definition.retain_resources,
+                ),
+                self.context,
+                provider,
+            ).values()
+            """
+            self._retain_resources = self.definition.retain_resources
+
+        return self._retain_resources
 
     @property
     def blueprint(self):


### PR DESCRIPTION
This change was a bit more involved as in order to delete a Lambda@Edge resource StackDestroy must be called twice. Once without RetainResources, then again with RetainResources since the stack _must_ be in a failed state for RetainResources to work.
    
https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeleteStack.html
    
The following functionality were added to support retain_resources;   
    * The destroy command nows emits and checks for a failed state.
    * If the state is failed and `retain_resources` is defined retry the
      destory passing RetainResources otherwise run as before.

![selection_003](https://user-images.githubusercontent.com/103125/40746897-8146b204-6410-11e8-93ed-676412a7a5a4.png)
![selection_002](https://user-images.githubusercontent.com/103125/40746898-815fad5e-6410-11e8-889c-b9f2f012fe1e.png)